### PR TITLE
VCR test listener PHP 8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php-vcr/php-vcr": "^1.4",
-        "php": "^7.1"
+        "php": "^7.1 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0"


### PR DESCRIPTION
This makes it compatible so that we can install this package with Composer without the `--ignore-platform-reqs` option when using PHP 8.1.